### PR TITLE
Fix: Update icon references in HTML to use generated PNGs

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,9 +11,12 @@
     <meta name="theme-color" content="#000000">
     
     <!-- Icons -->
-    <link rel="icon" type="image/png" sizes="32x32" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAIklEQVRYhe3BMQEAAADCoPVPbQhfoAAAAAAAAAAAAAAAAIC3AcH0AAFjNpu1AAAAAElFTkSuQmCC">
-    <link rel="icon" type="image/png" sizes="16x16" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAIklEQVQ4je3BMQEAAADCoPVPbQhfoAAAAAAAAAAAAAAAAIC3AcH0AAGjNpu1AAAAAElFTkSuQmCC">
-    <link rel="apple-touch-icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAYAAABS3GwHAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAj0lEQVR4nO3BMQEAAADCoPVPbQhfoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAODNAcH0AAHjNpu1AAAAAElFTkSuQmCC">
+    <link rel="icon" href="favicon.ico" type="image/x-icon">
+    <link rel="icon" type="image/png" sizes="16x16" href="icons/icon-16x16.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="icons/icon-32x32.png">
+    <link rel="icon" type="image/png" sizes="96x96" href="icons/icon-96x96.png">
+    <link rel="icon" type="image/png" sizes="192x192" href="icons/icon-192x192.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="icons/icon-180x180.png">
     
     <!-- CSS -->
     <link rel="stylesheet" href="styles/main.css">


### PR DESCRIPTION
- I modified index.html to link to standard PNG icon files (e.g., icon-32x32.png) in the 'icons/' directory and to 'favicon.ico' at the root.
- These files are intended to be generated by the 'icons/generate-icons.sh' script.
- This replaces the placeholder data-URL icons.
- I verified that icon paths in js/app.js for notifications are already consistent with the generated icon names.

You need to ensure ImageMagick is installed and run the 'icons/generate-icons.sh' script to create the actual icon files.