### PR TITLE
Here's the plan:

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,9 +11,12 @@
     <meta name="theme-color" content="#000000">
     
     <!-- Icons -->
-    <link rel="icon" type="image/png" sizes="32x32" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAIklEQVRYhe3BMQEAAADCoPVPbQhfoAAAAAAAAAAAAAAAAIC3AcH0AAFjNpu1AAAAAElFTkSuQmCC">
-    <link rel="icon" type="image/png" sizes="16x16" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAIklEQVQ4je3BMQEAAADCoPVPbQhfoAAAAAAAAAAAAAAAAIC3AcH0AAGjNpu1AAAAAElFTkSuQmCC">
-    <link rel="apple-touch-icon" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMAAAADACAYAAABS3GwHAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAj0lEQVR4nO3BMQEAAADCoPVPbQhfoAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAODNAcH0AAHjNpu1AAAAAElFTkSuQmCC">
+    <link rel="icon" href="favicon.ico" type="image/x-icon">
+    <link rel="icon" type="image/png" sizes="16x16" href="icons/icon-16x16.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="icons/icon-32x32.png">
+    <link rel="icon" type="image/png" sizes="96x96" href="icons/icon-96x96.png">
+    <link rel="icon" type="image/png" sizes="192x192" href="icons/icon-192x192.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="icons/icon-180x180.png">
     
     <!-- CSS -->
     <link rel="stylesheet" href="styles/main.css">

--- a/vercel.json
+++ b/vercel.json
@@ -2,18 +2,36 @@
   "version": 2,
   "builds": [
     {
+      "src": "package.json",
+      "use": "@vercel/static-build",
+      "config": {
+        "distDir": "."
+      }
+    },
+    {
       "src": "server.js",
       "use": "@vercel/node"
     }
   ],
   "routes": [
     {
+      "handle": "filesystem"
+    },
+    {
       "src": "/signaling",
-      "dest": "/server.js"
+      "dest": "server.js"
+    },
+    {
+      "src": "/ws",
+      "dest": "server.js"
+    },
+    {
+      "src": "/api/(.*)",
+      "dest": "server.js"
     },
     {
       "src": "/(.*)",
-      "dest": "/server.js"
+      "dest": "index.html"
     }
   ],
   "env": {


### PR DESCRIPTION
- Update index.html to reference generated PNG icons instead of data-URLs.
- Update vercel.json to correctly serve static files (HTML, CSS, JS, icons) and handle server.js as a serverless function.

Here's what you'll need to do:

- Generate icon assets locally using 'icons/generate-icons.sh' and commit them.
- Ensure server.js exports the Express app and does not call app.listen().
- Verify and adjust routes in vercel.json as per server.js logic (especially WebSocket and API paths).